### PR TITLE
Pass environment down to build task

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ If you don't install the redis- and s3-adapters you will need to use a custom ad
   },
 
   "staging": {
+    "buildEnv": "staging", // Override the environment passed to the ember asset build. Defaults to 'production'
     "store": {
       "host": "staging-redis.example.com",
       "port": 6379

--- a/deploy.json
+++ b/deploy.json
@@ -12,6 +12,7 @@
   },
 
   "staging": {
+    "buildEnv": "staging",
     "store": {
       "host": "staging-redis.firstiwaslike.com",
       "port": 6379

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -1,3 +1,5 @@
+var ConfigurationReader = require('../../utilities/configuration-reader');
+
 module.exports = {
   name: 'deploy',
   description: 'Deploys an ember-cli app',
@@ -12,6 +14,9 @@ module.exports = {
     var AssetsTask      = require('../tasks/assets');
     var BuildTask       = this.tasks.Build;
 
+    var config = new ConfigurationReader({
+      environment: commandOptions.environment
+    });
     var buildTask = new BuildTask({
       ui: this.ui,
       analytics: this.analytics,
@@ -19,7 +24,7 @@ module.exports = {
 
     });
     var buildOptions = {
-      environment: "production",
+      environment: config.buildEnv || 'production',
       outputPath: "dist/",
       watch: false,
       disableAnalytics: false

--- a/utilities/configuration-reader.js
+++ b/utilities/configuration-reader.js
@@ -16,6 +16,7 @@ function ConfigurationReader(options) {
 
   this.store = this._config[this._environment].store;
   this.assets = this._config[this._environment].assets;
+  this.buildEnv = this._config[this._environment].buildEnv || 'production';
 }
 
 module.exports = ConfigurationReader;


### PR DESCRIPTION
A fix for #21

There might be other considerations to make before merging this, but it works for my use case.

This will default to a development build. This may not be ideal, but it seemed better than making any other assumptions. And defaulting to `production` seems like a bad idea.

Another idea, is that we provide a convention in `deploy.json` to pass build properties to the build task. That would potentially decouple the deploy environment from the ember build environment. e.g. `deploy.json` could look like:
```
{
  staging: {
    build: {
      assetHost: 'cdn.bustle.com',
      apiHost: 'staging.api.bustle.com'
    }
  }
}
```
Does that make sense?
