### PR TITLE
Allow custom config file

### DIFF
--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -5,7 +5,8 @@ module.exports = {
 
   availableOptions: [
     { name: 'environment', type: String, default: 'development' },
-    { name: 'revision', type: String }
+    { name: 'revision', type: String },
+    { name: 'config-file', type: String, default: 'deploy.json' }
   ],
 
   run: function(commandOptions, rawArgs) {

--- a/lib/commands/assets.js
+++ b/lib/commands/assets.js
@@ -4,7 +4,8 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' }
+    { name: 'environment', type: String, default: 'development' },
+    { name: 'config-file', type: String, default: 'deploy.json' }
   ],
 
   run: function(commandOptions, rawArgs) {

--- a/lib/commands/deploy-index.js
+++ b/lib/commands/deploy-index.js
@@ -4,7 +4,8 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' }
+    { name: 'environment', type: String, default: 'development' },
+    { name: 'config-file', type: String, default: 'deploy.json' }
   ],
 
   run: function(commandOptions, rawArgs) {

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -6,7 +6,8 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' }
+    { name: 'environment', type: String, default: 'development' },
+    { name: 'config-file', type: String, default: 'deploy.json' }
   ],
 
   run: function(commandOptions, rawArgs) {
@@ -15,7 +16,8 @@ module.exports = {
     var BuildTask       = this.tasks.Build;
 
     var config = new ConfigurationReader({
-      environment: commandOptions.environment
+      environment: commandOptions.environment,
+      configFile: commandOptions.configFile
     });
     var buildTask = new BuildTask({
       ui: this.ui,

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -4,7 +4,8 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' }
+    { name: 'environment', type: String, default: 'development' },
+    { name: 'config-file', type: String, default: 'deploy.json' }
   ],
 
   run: function(commandOptions, rawArgs) {

--- a/lib/tasks/activate.js
+++ b/lib/tasks/activate.js
@@ -13,7 +13,8 @@ module.exports = Task.extend({
     var ui     = this.ui;
     var revision = options.revision;
     var config = new ConfigurationReader({
-      environment: options.environment
+      environment: options.environment,
+      configFile: options.configFile
     });
     var adapterType = config.store.type || 'redis';
     var Adapter = new AdapterRegistry({ project: this.project })

--- a/lib/tasks/assets.js
+++ b/lib/tasks/assets.js
@@ -20,7 +20,8 @@ module.exports = Task.extend({
     var broccoli  = require('broccoli');
 
     var config = new ConfigurationReader({
-      environment: options.environment
+      environment: options.environment,
+      configFile: options.configFile
     });
 
     var fileTreeOrPath;
@@ -28,7 +29,7 @@ module.exports = Task.extend({
       fileTreeOrPath = 'dist';
     } else {
       var gzipFiles = require('broccoli-gzip');
-      
+
       fileTreeOrPath = gzipFiles('dist', {
         extensions: config.assets.gzipExtensions ? config.assets.gzipExtensions : ['js', 'css', 'svg'],
         appendSuffix: false
@@ -39,15 +40,16 @@ module.exports = Task.extend({
 
     return builder.build()
       .then(this.processBuildResult.bind(this))
-      .then(this.uploadAssets.bind(this, options.environment))
+      .then(this.uploadAssets.bind(this, options.environment, options.configFile))
       .then(function() {
         builder.cleanup();
       });
   },
 
-  uploadAssets: function(environment) {
+  uploadAssets: function(environment, configFile) {
     var config = new ConfigurationReader({
-      environment: environment
+      environment: environment,
+      configFile: configFile
     });
     var assetsUploader = new AssetsUploader({
       ui: this.ui,

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -11,7 +11,8 @@ module.exports = Task.extend({
   run: function(options) {
     var ui = this.ui;
     var config = new ConfigurationReader({
-      environment: options.environment
+      environment: options.environment,
+      configFile: options.configFile
     });
 
     var adapterType = config.store.type || 'redis';

--- a/lib/tasks/list.js
+++ b/lib/tasks/list.js
@@ -7,7 +7,8 @@ module.exports = Task.extend({
   run: function(options) {
     var ui     = this.ui;
     var config = new ConfigurationReader({
-      environment: options.environment
+      environment: options.environment,
+      configFile: options.configFile
     });
     var adapterType = config.store.type || 'redis';
     var Adapter = new AdapterRegistry({ project: this.project })


### PR DESCRIPTION
This PR adds the `--config-file` option to every command. It allows to store the deploy config in another location than `deploy.json`. Moreover, it allows to read the config from a `.js` file and, by extension, to take advantage of environment variables.