### PR TITLE
Link to new S3 Index Adapter

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,7 +214,8 @@ After adding your custom ember-deploy-addon to your project as an ember-cli-addo
 ### Existing Custom Adapters
 The following adapters have already been developed:
 * [ember-deploy-redis](https://github.com/LevelbossMike/ember-deploy-redis), index-adapter for [Redis](http://redis.io)
-* [ember-deploy-s3](https://github.com/LevelbossMike/ember-deploy-s3), assets-adapter for AWS [s3](aws.amazon.com/s3/)
+* [ember-deploy-s3](https://github.com/LevelbossMike/ember-deploy-s3), assets-adapter for AWS [S3](http://aws.amazon.com/s3/)
+* [ember-deploy-s3-index](https://github.com/Kerry350/ember-deploy-s3-index), index-adapter for AWS [S3](http://aws.amazon.com/s3/)
 * [ember-deploy-azure](https://github.com/duizendnegen/ember-deploy-azure), index-adapter and assets-adapter for Azure Tables & Blob Storage respectively
 
 ### Index-Adapters


### PR DESCRIPTION
Serve the `index.html` file out of S3 directly or use S3 as storage behind a proxy instead of Redis. Addon written by @Kerry350, feedback welcome!

(Also minor edit: use the scheme for S3 link, and name S3 with a capital S.)