### PR TITLE
Allow defining of tagging adapter in deploy.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,8 @@ The following adapters have already been developed:
 * [ember-deploy-s3](https://github.com/LevelbossMike/ember-deploy-s3), assets-adapter for AWS [S3](http://aws.amazon.com/s3/)
 * [ember-deploy-s3-index](https://github.com/Kerry350/ember-deploy-s3-index), index-adapter for AWS [S3](http://aws.amazon.com/s3/)
 * [ember-deploy-azure](https://github.com/duizendnegen/ember-deploy-azure), index-adapter and assets-adapter for Azure Tables & Blob Storage respectively
+* [ember-deploy-tagging-index-sha](https://github.com/jamesfid/ember-deploy-tagging-index-sha), tagging-adapter to use `dist/index.html`'s SHA representation as opposed to the default tagging-adapter's usage of `git rev-parse HEAD`.
+
 
 ### Index-Adapters
 

--- a/README.md
+++ b/README.md
@@ -78,7 +78,8 @@ If you don't install the redis- and s3-adapters you will need to use a custom ad
       "accessKeyId": "<your-access-key-goes-here>",
       "secretAccessKey": "<your-secret-access-key-goes-here>",
       "bucket": "<your-bucket-name>"
-    }
+    },
+    "tagging": "sha" // the default tagging-adapter is 'sha' (uses git rev-parse HEAD).
   },
 
   "staging": {

--- a/utilities/configuration-reader.js
+++ b/utilities/configuration-reader.js
@@ -8,15 +8,16 @@ function ConfigurationReader(options) {
   var root              = process.cwd();
   var defaultConfigPath = 'deploy.json';
 
-  this._options = options || {};
-  this._environment = this._options.environment || 'development';
+  this._options      = options || {};
+  this._environment  = this._options.environment || 'development';
   this._deployConfig = this._options.configFile || defaultConfigPath;
 
-  this._config = require(path.join(root, this._deployConfig));
-
-  this.store = this._config[this._environment].store;
-  this.assets = this._config[this._environment].assets;
+  this._config  = require(path.join(root, this._deployConfig));
+  
+  this.store    = this._config[this._environment].store;
+  this.assets   = this._config[this._environment].assets;
   this.buildEnv = this._config[this._environment].buildEnv || 'production';
+  this.tagging  = this._config[this._environment].tagging || 'sha';
 }
 
 module.exports = ConfigurationReader;


### PR DESCRIPTION
In writing a custom `tagging-adapter`, I noticed that the `tagging` configuration value (referenced in [lib/tasks/deploy-index.js](https://github.com/LevelbossMike/ember-deploy/blob/master/lib/tasks/deploy-index.js#L18)) never actually gets set by the `configuration-reader`.  This PR should fix the issue as well as show in the README an example of defining a custom `tagging-adapter` for usage.

### Questions
One issue that may need to be addressed is where the defaulting of configuration values should be done.  Presently I have the `tagging-adapter` defaulted to `sha` in the `configuration-reader` itself.  This defaulting is duplicated in [lib/tasks/deploy-index.js](https://github.com/LevelbossMike/ember-deploy/blob/master/lib/tasks/deploy-index.js#L18).  

What is the preferred pattern for defaulting configuration values?  I can adjust the PR accordingly once this is defined.
