### PR TITLE
Match ember-cli's build command aliases by supporting --prod and --dev

### DIFF
--- a/lib/commands/activate.js
+++ b/lib/commands/activate.js
@@ -4,7 +4,7 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' },
+    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'revision', type: String },
     { name: 'deploy-config-file', type: String, default: 'deploy.json' }
   ],

--- a/lib/commands/assets.js
+++ b/lib/commands/assets.js
@@ -4,7 +4,7 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' },
+    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'deploy-config-file', type: String, default: 'deploy.json' }
   ],
 

--- a/lib/commands/deploy-index.js
+++ b/lib/commands/deploy-index.js
@@ -4,7 +4,7 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' },
+    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'deploy-config-file', type: String, default: 'deploy.json' }
   ],
 

--- a/lib/commands/deploy.js
+++ b/lib/commands/deploy.js
@@ -6,7 +6,7 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' },
+    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'deploy-config-file', type: String, default: 'deploy.json' }
   ],
 

--- a/lib/commands/list.js
+++ b/lib/commands/list.js
@@ -4,7 +4,7 @@ module.exports = {
   works: 'insideProject',
 
   availableOptions: [
-    { name: 'environment', type: String, default: 'development' },
+    { name: 'environment', type: String, default: 'development', aliases: ['e',{'dev' : 'development'}, {'prod' : 'production'}] },
     { name: 'deploy-config-file', type: String, default: 'deploy.json' }
   ],
 


### PR DESCRIPTION
Quality of life change to support `--prod`, `--dev`, `-e production`, etc on all commands similarly to ember-cli's build commands.

Reference [ember-cli build.js](https://github.com/ember-cli/ember-cli/blob/master/lib/commands/build.js)