### PR TITLE
Removed erroneous conflict markers.

### DIFF
--- a/lib/tasks/assets.js
+++ b/lib/tasks/assets.js
@@ -48,14 +48,10 @@ module.exports = Task.extend({
 
   uploadAssets: function(environment, configFile) {
     var config = new ConfigurationReader({
-<<<<<<< HEAD
       environment: environment,
       configFile: configFile
-    });
-=======
-      environment: environment
     }).config;
->>>>>>> Encapsulate defaults in a config model
+    
     var assetsUploader = new AssetsUploader({
       ui: this.ui,
       config: config,


### PR DESCRIPTION
Quick fix to remove some conflict markers causing issues when calling `uploadAssets()`.